### PR TITLE
add capsys_suspender fixture to prevent capture of stdin/out/err

### DIFF
--- a/src/pytest_flyte/__init__.py
+++ b/src/pytest_flyte/__init__.py
@@ -1,4 +1,5 @@
 from pytest_flyte.plugin import (
+    capsys_suspender,
     docker_cleanup,
     docker_compose,
     docker_compose_file,

--- a/src/pytest_flyte/plugin.py
+++ b/src/pytest_flyte/plugin.py
@@ -75,8 +75,19 @@ def flyte_workflows_register(docker_compose):
 
 
 @pytest.fixture(scope="session")
-def docker_compose(docker_compose_file, docker_compose_project_name):
-    return DockerComposeExecutor(docker_compose_file, docker_compose_project_name)
+def docker_compose(docker_compose_file, docker_compose_project_name, capsys_suspender):
+
+    class _DockerComposeExecutor(DockerComposeExecutor):
+        """
+        This subclass wraps the DockerComposeExecutor.execute method so that pytest capture sys stdin/out/err
+        is suspended whenever docker compose execute is invoked. This is so that the end user doesn't have to
+        use capsys_suspender when using this fixture.
+        """
+        def execute(self, subcommand):
+            with capsys_suspender():
+                super().execute(subcommand)
+
+    return _DockerComposeExecutor(docker_compose_file, docker_compose_project_name)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
using fixtures that rely on `docker_compose.execute` don't work unless the
`pytest -s` flag is provided, as the docker pytest plugin relies on
subprocess.check_output calls to determine whether a command is successful
or not. this diff adds a `capsys_suspender` to globally suspend capturing
stdin/out/err so that success of docker-compose exec commands can be correctly
detected

Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>