### PR TITLE
use FileSystemLoader instead of PackageLoader

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="pytest-flyte",
     version="0.0.0+dev0",
     packages=find_packages("src"),
-    entry_points={"pytest11": ["flyte = pytest_flyte.plugin"]},
+    entry_points={"pytest11": ["flyte = pytest_flyte"]},
     package_dir={"": "src"},
     description="Pytest fixtures for simplifying Flyte integration testing",
     include_package_data=True,

--- a/src/pytest_flyte/plugin.py
+++ b/src/pytest_flyte/plugin.py
@@ -8,10 +8,10 @@ import pytest
 from flytekit.clients import friendly
 from pytest_docker.plugin import DockerComposeExecutor
 
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, FileSystemLoader
 
 PROJECT_ROOT = os.path.dirname(__file__)
-TEMPLATE_ENV = Environment(loader=PackageLoader("pytest_flyte"))
+TEMPLATE_ENV = Environment(loader=FileSystemLoader(os.path.join(PROJECT_ROOT, "templates")))
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
after `pip install <path>/<to>/pytest-flyte` locally, tried running tests,
with the following error:

```
self = <pkg_resources.NullProvider object at 0x7f9a5022a640>
path = '/Users/nielsbantilan/miniconda3/envs/flytekit/lib/python3.8/site-packages/pytest_flyte/templates/kustomization.yaml.tmpl'

    def _has(self, path):
>       raise NotImplementedError(
            "Can't perform this operation for unregistered loader type"
        )
E       NotImplementedError: Can't perform this operation for unregistered loader type

../../miniconda3/envs/flytekit/lib/python3.8/site-packages/pkg_resources/__init__.py:1458: NotImplementedError
```

there appears to be a bug when trying to use the PackageLoader. Installing in
development mode with `pip install -e` seems to circumvent this issue.

Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>