### PR TITLE
Remove kustomize from initialization

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,7 +42,7 @@ decorator==5.0.9
     # via
     #   -c requirements.txt
     #   retry
-deprecated==1.2.12
+deprecated==1.2.13
     # via
     #   -c requirements.txt
     #   flytekit
@@ -66,11 +66,11 @@ flyteidl==0.20.2
     # via
     #   -c requirements.txt
     #   flytekit
-flytekit==0.22.0
+flytekit==0.22.1
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
-grpcio==1.39.0
+grpcio==1.40.0
     # via
     #   -c requirements.txt
     #   flytekit

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ dataclasses-json==0.5.5
     # via flytekit
 decorator==5.0.9
     # via retry
-deprecated==1.2.12
+deprecated==1.2.13
     # via flytekit
 dirhash==0.2.1
     # via flytekit
@@ -59,9 +59,9 @@ docstring-parser==0.10
     # via flytekit
 flyteidl==0.20.2
     # via flytekit
-flytekit==0.22.0
+flytekit==0.22.1
     # via pytest-flyte
-grpcio==1.39.0
+grpcio==1.40.0
     # via flytekit
 idna==3.2
     # via requests

--- a/src/pytest_flyte/docker/Dockerfile
+++ b/src/pytest_flyte/docker/Dockerfile
@@ -1,15 +1,6 @@
 FROM ghcr.io/flyteorg/flyte-sandbox:dind
 
-# Install kustomize
-ARG KUSTOMIZE_VERSION="v4.0.5"
-RUN wget -q -O /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
-    && tar -xf /tmp/kustomize.tar.gz -C /flyteorg/bin \
-    && chmod +x /flyteorg/bin/kustomize \
-    && rm /tmp/kustomize.tar.gz
-
-COPY flyte-entrypoint-override.sh /flyteorg/bin/
-
 # Enable docker buildkit
 ENV DOCKER_BUILDKIT=1
 
-ENTRYPOINT ["tini", "flyte-entrypoint-override.sh", "flyte-entrypoint.sh"]
+ENTRYPOINT ["tini", "flyte-entrypoint.sh"]

--- a/src/pytest_flyte/docker/flyte-entrypoint-override.sh
+++ b/src/pytest_flyte/docker/flyte-entrypoint-override.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -eo pipefail
-
-cp /flyteorg/share/flyte_generated.yaml /opt/flyteorg/share/deployment
-kustomize build /opt/flyteorg/share/deployment | tee /flyteorg/share/flyte_generated.yaml
-
-exec "$@"


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

The sandbox no longer relies on `kustomize` in its initialization scripts. This has the nice side effect that it simplifies the sandbox initialized in by `pytest-flyte`.